### PR TITLE
feat: support running each test multiple times

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "This is a set of fine grained test cases(prompts) to benchmark the reasoning and generation of LLMs in complex scenarios. Please note that this benchmark does NOT mean to be a comprehensive test against LLMs. This project is originated from an internal project of babel.cloud, the purpose of the project is to test LLMs' performance in context understanding and instruction compliance.",
   "main": "index.js",
   "scripts": {
-    "eval": "promptfoo eval --no-cache -j 8 -o ~/.promptfoo/output/latest.json",
+    "eval": "promptfoo eval --no-cache --repeat ${npm_config_repeat} -j 8 -o ~/.promptfoo/output/latest.json",
     "render": "ts-node utils/generateEvalScore.ts && ts-node utils/render.ts",
     "start": "npm run eval;npm run render"
   },

--- a/utils/render.ts
+++ b/utils/render.ts
@@ -10,6 +10,7 @@ const structure = fs.readFileSync(path.join(os.homedir(), '.promptfoo/output/lat
 const scoreData = JSON.parse(score);
 const structureData = JSON.parse(structure)
 const maxColumnWidth = 25;
+const repeat = scoreData[0].scores[0].repeat || 1;
 
 let maxScores = {
     total_score: structureData.max_total_score,
@@ -34,7 +35,7 @@ let verticalTestCasesTable = new Table({
     head: ['Test Case / LLM ID'].concat(structureData.llms).map(header => chalk.blue(header))
 });
 
-let verticalRows: any[] = [['Total Score']];
+let verticalRows: any[] = [[`Total Score (repeat: ${repeat})`]];
 
 structureData.testcases.forEach((testcase: any) => {
     verticalRows.push([testcase.name]);


### PR DESCRIPTION
Use `npm run start --repeat=2` to run each test multiple times. If `repeat` is not specified, each test will run only once.