### PR TITLE
add response logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@ test_results
 draft_prompts
 promptfooconfig.yaml
 testcases/__pycache__
-experiments/

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ test_results
 draft_prompts
 promptfooconfig.yaml
 testcases/__pycache__
+experiments/


### PR DESCRIPTION
# Add Response Logs and Reporting for LLM Tests

This update introduces logging functionality for capturing:

1. Prompts and Responses for each test case.
2. A report summarizing the performance of each Large Language Model (LLM).

All log files will be stored in a structured format under the experiments directory, organized by timestamp and LLM name.

File Structure:
```
experiments/
  ├── timestamp/
  │    ├── LLM-name/
  │    │    ├── report.json
  │    │    └── {testcase-name}-{index}.md
```

- **report.json**: Contains a summary of the LLM's performance.
- **{testcase-name}-{index}.md**: Stores detailed logs of each test's prompt and response.
